### PR TITLE
chore(deps): remove unused dependencies and redundant plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
         <main.basedir>${basedir}/../..</main.basedir>
     </properties>
 
@@ -56,33 +54,18 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.22.1</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.graphql</groupId>
-            <artifactId>spring-graphql-test</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>com.sergiovitorino.hexagonalarchitectureexample.Start</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
@@ -140,15 +123,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.15.0</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary

- **Remove `spring-graphql-test`**: 0% usage — GraphQL tests use `TestRestTemplate`, not `HttpGraphQlTester`
- **Change H2 scope to `runtime`**: no Java code imports H2 classes directly, only used by Hibernate via JDBC URL
- **Remove redundant `maven-jar-plugin`**: `spring-boot-maven-plugin` already configures `Start-Class` in MANIFEST
- **Remove redundant `maven-compiler-plugin`** and `maven.compiler.source/target` properties: `java.version=21` in Spring Boot parent handles this automatically

## Test plan

- [ ] `mvn clean verify` passes with all 54 tests green and JaCoCo check met
- [ ] No compilation errors after removing `spring-graphql-test`
- [ ] Application starts normally with `mvn spring-boot:run`
- [ ] GraphQL tests still pass using `TestRestTemplate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)