### PR TITLE
refactor: hexagonal architecture complete + observability/security hardening

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,6 +42,30 @@ jobs:
     - name: Build and verify with Maven
       run: mvn -B verify --file pom.xml
 
+  integration-tests-postgres:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache Maven packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: 21
+
+    - name: Run integration tests (Testcontainers + PostgreSQL)
+      run: mvn -B verify -Pit -DskipTests --file pom.xml
+
   security-scan:
     # Non-blocking OWASP Dependency Check.
     # Requires the NVD_API_KEY repository secret to be reliable; without it,

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ hs_err_pid*
 hexagonalarchitectureexample.iml
 .idea/*
 target/
+
+# AI tooling / local working artifacts
+.agents/
+.claude/
+roocline/
+TASKS.md
+claude-us06-completion.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Authentication was explicitly excluded (educational project). Fixes applied:
 
 ### Test Coverage Improvement
 
-Increased from 6 to 77 tests. Coverage: **98%+ instructions, 85%+ branches**. JaCoCo `check` goal enforces minimum 80% line coverage.
+Increased from 6 to 77 tests (later grown to 161 — see Post-Static-Analysis section). Coverage: **98%+ instructions, 85%+ branches**. JaCoCo `check` goal enforces minimum 80% line coverage.
 
 Tests:
 - **GraphQL** (7 slice -- `@GraphQlTest`): normal query, userName filter, negative pageNumber, pageSize exceeding limit, pageSize zero, invalid orderBy, orderBy by id
@@ -63,8 +63,8 @@ Performed in May 2026. Implemented findById, update, and delete operations acros
 
 CRUD operations added:
 - **findById**: `UserRepositoryPort.findById(UUID)`, `UserRepositoryAdapter` implementation, `UserService.findById` (`@Transactional(readOnly=true)`), `UserNotFoundException` in `domain/exception/`, `GET /rest/user/{id}` endpoint, `findById(id: ID!): User!` GraphQL query
-- **update**: `UpdateCommand` record (`@NotNull id`, `@NotBlank @SafeHtml @Size(min=3,max=100) name`), `UserService.update`, `PUT /rest/user/{id}`, `updateUser` GraphQL mutation
-- **delete**: `DeleteCommand` record (`@NotNull id`), `UserService.delete` (verifies existence before deleting), `DELETE /rest/user/{id}` returns 204, `deleteUser` GraphQL mutation returns `Boolean!`
+- **update**: `UpdateCommand` record (`@NotNull id`, `@NotBlank @SafeHtml @Size(min=5,max=100) name`), `UserService.update`, `PUT /rest/user/{id}`, `updateUser` GraphQL mutation
+- **delete**: `DeleteCommand` record (`@NotNull id`), `UserService.delete` (uses `existsById` before `deleteById` to avoid loading the entity), `DELETE /rest/user/{id}` returns 204, `deleteUser` GraphQL mutation returns `Boolean!`
 
 OpenAPI / Swagger:
 - `springdoc-openapi-starter-webmvc-ui` added to `pom.xml`
@@ -85,7 +85,23 @@ Code review feedback (May 2026):
 - `GlobalExceptionHandler.handleConstraintViolation` added with unit test
 - `@Validated` + `@Valid` wired on `UserCommandHandler.handle(UpdateCommand)`
 
-Test count: **119 tests** total. Mutation score: 97%.
+Test count: **161 tests** total. Mutation score: 97%.
+
+### Post-Static-Analysis Fixes (May 2026)
+
+Performed in May 2026. Addressed 13 tasks from static analysis.
+
+- **`UpdateCommand` min=5**: `@Size(min=5,max=100)` on name. `V1__init.sql` CHECK constraint updated to `>= 5`. `PUT /rest/user/{id}` now uses `UpdateUserRequest` DTO (not `SaveCommand`) for request body.
+- **GraphQL exception mapping**: `GraphQlExceptionResolver` (`infrastructure/graphql/`) extends `DataFetcherExceptionResolverAdapter`. Maps `UserNotFoundException` → `NOT_FOUND`, `DomainValidationException`/`IllegalArgumentException` → `BAD_REQUEST`, `ConstraintViolationException` → `BAD_REQUEST`. Covered by `GraphQlExceptionResolverIntegrationTest`.
+- **CORS X-Correlation-Id**: `WebConfig.allowedHeaders` includes `"X-Correlation-Id"`. Covered by new test in `WebConfigCorsTest`.
+- **MDC GraphQL TODO**: `GraphQlCorrelationInterceptor` has explicit TODO documenting that `doFirst`/`doFinally` run on the reactor thread; with virtual threads the data fetcher thread may not see MDC — solution is `ContextRegistry`/`ThreadLocalAccessor`.
+- **`UserService.delete` uses `existsById`**: Added `existsById(UUID)` to `UserRepositoryPort`, `UserRepositoryAdapter`, and `UserService.delete`. No longer loads the entity unnecessarily. Test updated with `inOrder(existsById, deleteById)`.
+- **`Initialize` readable names**: Seeds `"User-1-<6hex>"` through `"User-6-<6hex>"` (length >= 5, human-readable).
+- **`RateLimitProperties.cacheMaximumSize`**: New field (default 100000), used by `RateLimitFilter`. Property `ratelimit.cache-maximum-size` in `application.properties`.
+- **Dead code Relay removed**: Deleted `UserConnection`, `UserEdge`, `PageInfo` DTOs and `CursorCodec` + its test. Zero references remain.
+- **`bucket4j-core` bump**: 8.14.0 does not exist in Maven Central — kept at 8.10.1.
+- **`schema.graphqls` UUID comments**: `# ID! expects UUID string` comment added above `findById`, `updateUser`, `deleteUser`.
+- **`logback-spring.xml` scan removed**: Root `<configuration>` no longer has `scan="true"` — no dynamic reload in any profile (including prod).
 
 ### Technical Debt Cleanup
 
@@ -154,40 +170,61 @@ src/main/java/com/sergiovitorino/hexagonalarchitectureexample/
   Start.java                                     # @SpringBootApplication entry point
   domain/
     model/User.java                              # Pure POJO domain model, UUID id, String name, @EqualsAndHashCode(of = "id"), no JPA annotations
-    exception/UserNotFoundException.java         # Domain exception thrown by findById/update/delete when user not found
-    repository/UserRepositoryPort.java           # Output port interface (findAll, save, findById, deleteById) -- domain contract for persistence
+    exception/
+      UserNotFoundException.java                 # Thrown by findById/update/delete when user not found (mapped to 404 / NOT_FOUND)
+      DomainValidationException.java             # Domain validation error (mapped to 400 / BAD_REQUEST in REST and GraphQL)
+    repository/UserRepositoryPort.java           # Output port interface (findAll, save, findById, existsById, deleteById) -- domain contract for persistence
   application/
     command/
-      UserCommandHandler.java                    # @Validated, handles all commands; @Valid on handle(UpdateCommand). @Value maxPageSize via constructor
+      UserCommandHandler.java                    # @Validated, handles List/Save/Update/Delete commands; @Valid on handle(UpdateCommand). @Value maxPageSize via constructor
       user/
         ListCommand.java                         # Java Record with validation annotations, uses String userName (not entity)
         SaveCommand.java                         # Java Record with @SafeHtml, @Size(min=5,max=100), @NotEmpty
-        UpdateCommand.java                       # Java Record: @NotNull id, @NotBlank @SafeHtml @Size(min=3,max=100) name
+        UpdateCommand.java                       # Java Record: @NotNull id, @NotBlank @SafeHtml @Size(min=5,max=100) name
         DeleteCommand.java                       # Java Record: @NotNull UUID id
     dto/
       UserResponse.java                          # Java Record DTO (UUID id, String name), decouples API from domain model
+      UpdateUserRequest.java                     # Java Record DTO used as PUT /rest/user/{id} request body (name-only); REST controller builds UpdateCommand from path id + body. Keeps UpdateCommand internal and the REST contract explicit (separate from SaveCommand)
+    event/
+      UserCreatedEvent.java                      # Java Record published by UserService after save
+      UserUpdatedEvent.java                      # Java Record published by UserService after update
+      UserDeletedEvent.java                      # Java Record published by UserService after delete
     validation/
       SafeHtml.java                              # Custom @SafeHtml constraint annotation
       SafeHtmlValidator.java                     # Jsoup XSS validator
     service/
-      UserService.java                           # findAll, save, findById, update, delete. Depends on UserRepositoryPort. @Transactional, @Slf4j
+      UserService.java                           # findAll, save, findById, update, delete. Depends on UserRepositoryPort. Publishes UserCreated/Updated/DeletedEvent via ApplicationEventPublisher. @Transactional, @Slf4j
   ui/
     rest/
-      UserRestController.java                    # @RestController GET/POST /rest/user, GET/PUT/DELETE /rest/user/{id}, @Operation annotations, returns UserResponse
+      UserRestController.java                    # @RestController GET/POST /rest/user, GET/PUT/DELETE /rest/user/{id}; PUT consumes UpdateUserRequest; @Operation annotations; returns UserResponse
     graphql/
       controller/
         UserGraphQLController.java               # @Controller, @QueryMapping findAll/findById, @MutationMapping updateUser/deleteUser, pure delegator
   infrastructure/
     config/
-      WebConfig.java                             # CORS configuration (origins from @Value via constructor)
+      WebConfig.java                             # CORS configuration (origins via @Value); allowedHeaders includes X-Correlation-Id
+      GraphQLConfig.java                         # GraphQL runtime wiring (instrumentation, depth/complexity limits)
+      OpenApiConfig.java                         # springdoc OpenAPI metadata bean
+      RateLimitConfig.java                       # Builds bucket4j buckets backed by Caffeine cache (sized via RateLimitProperties)
+      RateLimitFilter.java                       # Servlet filter applying per-client rate limit using the configured cache
+      RateLimitProperties.java                   # @ConfigurationProperties("ratelimit"): capacity, refill, cacheMaximumSize (default 100000)
+      SecurityHeadersFilter.java                 # Adds HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, CSP
     exception/
-      GlobalExceptionHandler.java                # @RestControllerAdvice, @Slf4j, 8 exception handlers (incl. ConstraintViolationException, UserNotFoundException)
+      GlobalExceptionHandler.java                # @RestControllerAdvice, @Slf4j, REST handlers (incl. ConstraintViolationException, UserNotFoundException, DomainValidationException)
+    graphql/
+      GraphQlExceptionResolver.java              # extends DataFetcherExceptionResolverAdapter; maps UserNotFoundException -> NOT_FOUND; DomainValidationException / IllegalArgumentException / ConstraintViolationException -> BAD_REQUEST
     seed/
-      Initialize.java                            # Seeds 6 random users (@Profile("!prod"))
+      Initialize.java                            # Seeds 6 readable users "User-N-<6hex>" (@Profile("!prod"))
+    observability/
+      UserMetrics.java                           # Micrometer Counters: users_created_total, users_updated_total, users_deleted_total
+      UserMetricsEventListener.java              # @TransactionalEventListener(AFTER_COMMIT) consuming application/event records, increments counters only after commit
+    web/
+      CorrelationIdFilter.java                   # OncePerRequestFilter, validates/propagates X-Correlation-Id header + MDC; static sanitize() reused by GraphQL interceptor
+      GraphQlCorrelationInterceptor.java         # WebGraphQlInterceptor, propagates correlation-id in GraphQL requests (TODO: virtual-thread MDC via ContextRegistry)
     persistence/
       UserEntity.java                            # JPA entity (@Table "users"), UUID id, @Column(length=100) name, @Index on name, toDomain()/fromDomain() mappers
       UserRepository.java                        # JpaRepository<UserEntity, UUID> interface
-      UserRepositoryAdapter.java                 # Implements UserRepositoryPort, encapsulates Example/ExampleMatcher, maps User<->UserEntity
+      UserRepositoryAdapter.java                 # Implements UserRepositoryPort (findAll, save, findById, existsById, deleteById), encapsulates Example/ExampleMatcher, maps User<->UserEntity
 ```
 
 ## Key Files
@@ -198,6 +235,10 @@ src/main/java/com/sergiovitorino/hexagonalarchitectureexample/
 - `src/main/java/.../domain/repository/UserRepositoryPort.java` - Output port interface (the hexagonal boundary)
 - `src/main/java/.../infrastructure/persistence/UserEntity.java` - JPA entity with `toDomain()`/`fromDomain()` mappers
 - `src/main/java/.../infrastructure/persistence/UserRepositoryAdapter.java` - Adapter implementing the output port
+- `src/main/java/.../infrastructure/graphql/GraphQlExceptionResolver.java` - GraphQL error mapping (NOT_FOUND / BAD_REQUEST classifications)
+- `src/main/java/.../infrastructure/config/RateLimitFilter.java` + `RateLimitProperties.java` - bucket4j-based rate limit, Caffeine cache sized by `ratelimit.cache-maximum-size`
+- `src/main/java/.../infrastructure/config/SecurityHeadersFilter.java` - HSTS / CSP / X-Frame-Options / X-Content-Type-Options / Referrer-Policy
+- `src/main/java/.../application/dto/UpdateUserRequest.java` - REST PUT request body for `/rest/user/{id}`
 - `.github/workflows/maven.yml` - CI pipeline (checkout@v4, setup-java@v5, temurin JDK 21)
 - `system.properties` - `java.runtime.version=21` (for Heroku-like deployments)
 
@@ -215,6 +256,81 @@ mvn test jacoco:report
 # Report at: target/site/jacoco/index.html
 ```
 
+### PostgreSQL + Flyway (US-06)
+
+Performed in May 2026. Added PostgreSQL support for production, Flyway schema management, and Testcontainers integration tests.
+
+Changes:
+- **`pom.xml`**: Added `org.postgresql:postgresql` (runtime), `org.flywaydb:flyway-core`, `org.flywaydb:flyway-database-postgresql`, `org.testcontainers:postgresql` (test), `org.testcontainers:junit-jupiter` (test), `org.springframework.boot:spring-boot-testcontainers` (test). Added Maven profile `it` with `maven-failsafe-plugin` to run ITs separately.
+- **`src/main/resources/db/migration/V1__init.sql`**: Creates `users` table (UUID PK, name VARCHAR(100) NOT NULL) and `idx_user_name` index. Flyway manages schema in prod.
+- **`src/main/resources/application-prod.properties`**: PostgreSQL datasource via env vars `${DB_URL}`, `${DB_USER}`, `${DB_PASSWORD}`; `ddl-auto=validate`; `flyway.enabled=true`.
+- **`src/main/resources/application.properties`** (dev): `spring.flyway.enabled=false` — H2 uses `ddl-auto=update`, Flyway not needed in dev.
+- **`src/test/resources/application-it.properties`**: `flyway.enabled=true`, `ddl-auto=validate` — used by Testcontainers IT.
+- **`UserRepositoryPostgresIT.java`**: `@SpringBootTest` + `@Testcontainers` + `@ServiceConnection`. Tests: save, findById, findById not found, findAll with filter, deleteById, deleteById not found, Flyway V1 applied (`flyway_schema_history`).
+
+Production environment variables required:
+- `DB_URL` — JDBC URL, e.g. `jdbc:postgresql://host:5432/dbname`
+- `DB_USER` — database username
+- `DB_PASSWORD` — database password
+
+Running integration tests (requires Docker):
+```bash
+mvn verify -Pit
+```
+
+## PostgreSQL + Flyway (US-06)
+
+Performed in May 2026. Added production-ready persistence with PostgreSQL and Flyway migrations, plus Testcontainers integration tests.
+
+Infrastructure changes:
+- **PostgreSQL driver**: `postgresql` dependency (runtime scope) added to `pom.xml`
+- **Flyway**: `flyway-core` + `flyway-database-postgresql` dependencies added. Migration `V1__init.sql` creates `users` table with `CONSTRAINT chk_name_min_length CHECK (length(name) >= 3)` and `idx_user_name` index
+- **application-prod.properties**: datasource reads from env vars `${DB_URL}`, `${DB_USER}`, `${DB_PASSWORD}`. Flyway configured with `validate-on-migrate=true` and `clean-disabled=true` (baseline-on-migrate NOT set — default false to prevent masking schema deviations). HikariCP `socketTimeout=30`, JPA `query.timeout=10000`
+
+Integration tests:
+- **`UserRepositoryPostgresIT`**: `@SpringBootTest` + `@Testcontainers` + `@ServiceConnection`. Uses `postgres:16-alpine` container. Annotated with `@Transactional` for test isolation. Profiles `{"it","prod"}` so `Initialize` seed is suppressed via `@Profile("!prod")`. Tests: Flyway migration applied, save, findById, findById not found, findAll with filter, deleteById, deleteById not found, findAll order descending, index `idx_user_name` exists
+- **Profile `it`**: `application-it.properties` overrides datasource placeholders so env vars are not required in test environment
+
+Running integration tests:
+```bash
+mvn verify -Pit
+```
+
+Environment variables required in production:
+- `DB_URL` — JDBC URL (e.g., `jdbc:postgresql://host:5432/dbname`)
+- `DB_USER` — database username
+- `DB_PASSWORD` — database password
+
+CI:
+- Job `integration-tests-postgres` in `.github/workflows/maven.yml` runs after `build` (`needs: build`). Uses `mvn verify -Pit -DskipTests`. GitHub Actions runners have Docker available for Testcontainers.
+
+## Observabilidade (US-07)
+
+Performed in May 2026. Added Prometheus metrics, structured JSON logs, and correlation-id propagation.
+
+Changes:
+- **`pom.xml`**: Added `io.micrometer:micrometer-registry-prometheus` (runtime) and `net.logstash.logback:logstash-logback-encoder:8.0`
+- **`application.properties`**: Exposes `prometheus` endpoint — `management.endpoints.web.exposure.include=health,info,prometheus`, `management.endpoint.prometheus.enabled=true`, `management.metrics.tags.application=hexagonal-architecture-example`
+- **`application-prod.properties`**: Same prometheus settings plus `management.server.port=9090` (internal port, not public 8080)
+- **`UserMetrics`** (`infrastructure/observability/`): Spring `@Component` with three Micrometer Counters: `users_created_total`, `users_updated_total`, `users_deleted_total`. Counters are incremented by `UserMetricsEventListener` after transaction commit.
+- **`UserMetricsEventListener`** (`infrastructure/observability/`): `@TransactionalEventListener(AFTER_COMMIT, fallbackExecution=true)` — listens for `UserCreatedEvent`, `UserUpdatedEvent`, `UserDeletedEvent` published by `UserService`. Counters only increment after successful commit, preventing inflation from rolled-back transactions.
+- **`application/event/`**: `UserCreatedEvent`, `UserUpdatedEvent`, `UserDeletedEvent` — plain Java records. `UserService` publishes via Spring's `ApplicationEventPublisher` (standard Spring API, not infrastructure-specific).
+- **`logback-spring.xml`**: Profile `!prod` (all non-prod profiles: dev, test, IT, default) — plain colorido console with `%X{correlationId}`. Profile `prod` — JSON via `LoggingEventCompositeJsonEncoder` with fields `@timestamp`, `level`, `logger`, `message`, `thread`, `mdc` (includes `correlationId`), `stack_trace`.
+- **`CorrelationIdFilter`** (`infrastructure/web/`): `OncePerRequestFilter` at `Ordered.HIGHEST_PRECEDENCE`. Validates `X-Correlation-Id` header against `Pattern "^[a-zA-Z0-9\\-]{1,64}$"` — rejects null/blank/> 64 chars/invalid chars and generates a new UUID (prevents log injection). Static `sanitize()` method reused by `GraphQlCorrelationInterceptor`.
+- **`GraphQlCorrelationInterceptor`** (`infrastructure/web/`): Implements `WebGraphQlInterceptor`. Delegates header validation to `CorrelationIdFilter.sanitize()`. Propagates correlation-id into MDC via `doFirst`/`doFinally` reactive hooks.
+
+Tests added:
+- `CorrelationIdFilterTest` (9 unit): header preserved, UUID generated when absent, MDC cleared after request, MDC cleared on chain exception, empty header generates UUID, MDC populated during chain, `\n` in header rejected, header > 64 chars rejected, chars outside `[a-zA-Z0-9-]` rejected
+- `UserMetricsEventListenerTest` (3 unit): onUserCreated increments created counter, onUserUpdated increments updated counter, onUserDeleted increments deleted counter
+- `ActuatorPrometheusIntegrationTest` (3 integration): 200 response, JVM metrics present, `users_total` counter after create
+
+Architecture notes:
+- `UserService` no longer imports `UserMetrics` — hexagonal boundary respected. The event-driven approach decouples application layer from infrastructure observability.
+- `UserMetrics` is called only from `UserMetricsEventListener` (infra→infra), zero application-layer dependency on Micrometer.
+- Micrometer 1.15.x + Prometheus client 1.x (OpenMetrics) exposes `users_created_total` as `users_total` (the client treats `_total` as a type suffix for the base name `users`).
+- MDC reactive propagation in GraphQL (`doFirst`/`doFinally`) has known limitations with virtual threads: the data fetcher runs on a different thread and may not see MDC set in the reactor hooks. Solution is `ContextRegistry` + `MdcThreadLocalAccessor` (micrometer-context-propagation). TODO documented in `GraphQlCorrelationInterceptor`.
+- Prometheus endpoint should NOT be exposed on the public internet without authentication. In production, `management.server.port=9090` isolates it on an internal port — or place behind a proxy with auth.
+
 ## Known Considerations
 
 - The `user` table is named `users` in `UserEntity` (`@Table(name = "users")`) because `user` is a reserved word in H2 2.x.
@@ -228,8 +344,13 @@ mvn test jacoco:report
 - `GET /rest/user` returns `Cache-Control: max-age=30`. Clients may see data up to 30 seconds stale. Adjust or remove if real-time data is needed.
 - `UserResponse` DTO is the API contract. New fields added to `User` domain model must be explicitly added to both `UserEntity` (persistence) and `UserResponse` (API) to be stored and exposed.
 - `@Column(length = 100)` on `UserEntity.name` is aligned with `@Size(max = 100)` on `SaveCommand`. If you change one, update the other.
-- Spring Boot Actuator exposes only `health` and `info` endpoints. Adding new endpoints requires updating `management.endpoints.web.exposure.include` in `application.properties`.
+- Spring Boot Actuator exposes `health`, `info`, and `prometheus` endpoints. Adding new endpoints requires updating `management.endpoints.web.exposure.include` in `application.properties`. In production, management runs on port 9090 (not 8080) to isolate metrics from public traffic.
 - `SafeHtml` and `SafeHtmlValidator` are in `application/validation/` (not in `infrastructure/`) so that `SaveCommand` (application layer) can use them without violating the hexagonal dependency direction (application must not depend on infrastructure).
+- **PUT `/rest/user/{id}` uses `UpdateUserRequest` (name-only) instead of `SaveCommand`**: keeps the REST request body explicit about what is mutable on update and avoids overloading the create command. The REST controller composes `UpdateCommand(pathId, body.name())` before delegating to `UserCommandHandler`. Validation on `UpdateCommand` (`@NotNull id`, `@NotBlank @SafeHtml @Size(min=5,max=100) name`) still runs at the handler boundary via `@Validated` + `@Valid`. Accepted DRY trade-off: a small body record duplicates one field but decouples the API contract from the command shape.
+- **`UserService.delete` uses `UserRepositoryPort.existsById(UUID)`** (not `findById`) to verify existence before issuing the `deleteById` call -- avoids loading and mapping the entity. Tests assert call order via `inOrder(existsById, deleteById)`.
+- **Validation reach**: `@Valid` is wired on `UserCommandHandler.handle(SaveCommand)` and `handle(UpdateCommand)`; combined with `@Validated` at class level, this enforces `SafeHtml`, `@Size`, `@NotBlank`, `@NotNull` for both REST and GraphQL entry points. Bean validation failures surface as `ConstraintViolationException` (handled in `GlobalExceptionHandler` -> 400 and in `GraphQlExceptionResolver` -> `BAD_REQUEST`).
+- **GraphQL error mapping is centralized in `infrastructure/graphql/GraphQlExceptionResolver`** (not in `GlobalExceptionHandler`, which is REST-only via `@RestControllerAdvice`). Adding a new domain exception requires updating both resolvers if it must be visible on both transports.
+- **Rate limit cache size is configurable** via `ratelimit.cache-maximum-size` (`RateLimitProperties.cacheMaximumSize`, default 100000). `bucket4j-core` is pinned at `8.10.1` -- newer versions referenced in earlier drafts (e.g. 8.14.0) are not published to Maven Central.
 
 ## Git Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,102 +1,149 @@
-# hexagonal-architecture-example
-This example shows how to implement the hexagonal architecture design pattern with REST and GraphQL.
+# Hexagonal Architecture Example
+
+Projeto educacional em Java/Spring Boot que demonstra a aplicacao pratica do padrao **Arquitetura Hexagonal (Ports & Adapters)** expondo um mesmo dominio via **REST** e **GraphQL**, com persistencia em PostgreSQL (prod) ou H2 (dev), observabilidade com Prometheus e seguranca enrijecida.
 
 ![Java CI with Maven](https://github.com/sergiovlvitorino/hexagonal-architecture-example/workflows/Java%20CI%20with%20Maven/badge.svg)
-
 [![codecov](https://codecov.io/gh/sergiovlvitorino/hexagonal-architecture-example/branch/master/graph/badge.svg)](https://codecov.io/gh/sergiovlvitorino/hexagonal-architecture-example)
 
-## Tech Stack
+## Visao Geral
 
-* Java 21 (LTS)
-* Spring Boot 3.5.9
-* Spring for GraphQL (schema-first)
-* Spring Data JPA + H2 (in-memory)
-* Lombok 1.18.42
-* Jsoup 1.22.1 (XSS prevention)
-* JaCoCo 0.8.14 (code coverage)
+O objetivo deste projeto e servir como **referencia didatica** para desenvolvedores que querem entender, na pratica, como:
 
-## Architecture
+- Isolar o dominio de detalhes de infraestrutura (JPA, HTTP, GraphQL).
+- Expor o mesmo caso de uso em multiplas interfaces (REST e GraphQL) reaproveitando a camada de aplicacao.
+- Aplicar boas praticas de seguranca, observabilidade, validacao e testes em um servico Spring Boot moderno.
 
-```
-src/main/java/
-  domain/
-    model/          User entity
-    repository/     UserRepository (JPA)
-  application/
-    command/        UserCommandHandler, ListCommand, SaveCommand (Records)
-    service/        UserService
-  ui/
-    rest/           UserRestController (GET/POST)
-    graphql/        UserGraphQLController (@QueryMapping)
-  infrastructure/
-    validations/    @SafeHtml custom annotation + SafeHtmlValidator
-    GlobalExceptionHandler, WebConfig, Initialize
-```
+Nao e um produto comercial. E um laboratorio de boas praticas com cobertura de testes acima de 98%, mutation score 97% e CI integrado.
 
-## Getting Started
+## Funcionalidades
 
-### Prerequisites
-* JDK 21
-* Maven 3.8+
+- **CRUD completo de User** via REST e GraphQL (`findAll`, `findById`, `create`, `update`, `delete`).
+- **Paginacao e ordenacao** com whitelist de campos (`id`, `name`) protegendo contra injection em `orderBy`.
+- **Filtro por nome** via `Example`/`ExampleMatcher` (case-insensitive, contains).
+- **Validacao Bean Validation** nos comandos (`@NotBlank`, `@Size`, `@SafeHtml` custom para XSS).
+- **OpenAPI / Swagger UI** documentando os endpoints REST.
+- **Observabilidade**: metricas Prometheus (`users_created_total`, `users_updated_total`, `users_deleted_total`), logs JSON em prod, correlation-id propagado via header `X-Correlation-Id`.
+- **Persistencia profissional**: PostgreSQL + Flyway em producao, H2 em desenvolvimento.
 
-### Running
+## Stack
+
+- **Java 21** (LTS, com Records e virtual threads habilitadas)
+- **Spring Boot 3.5.9** (Web MVC, Data JPA, Validation, Actuator)
+- **Spring for GraphQL** (schema-first)
+- **PostgreSQL 16** (producao) / **H2** (desenvolvimento)
+- **Flyway** (migracoes de schema)
+- **Springdoc OpenAPI** (Swagger UI)
+- **Micrometer + Prometheus** (metricas)
+- **Logstash Logback Encoder** (logs estruturados JSON)
+- **Lombok**, **Jsoup** (XSS), **JaCoCo** (cobertura), **PIT** (mutation testing)
+- **Testcontainers** (testes de integracao com PostgreSQL real)
+
+## Como Rodar
+
+### Pre-requisitos
+
+- JDK 21
+- Maven 3.8+
+- Docker (apenas para testes de integracao com PostgreSQL)
+
+### Desenvolvimento (perfil default, H2 in-memory)
+
 ```bash
 git clone https://github.com/sergiovlvitorino/hexagonal-architecture-example
 cd hexagonal-architecture-example
 mvn spring-boot:run
 ```
 
-### Running tests
+A aplicacao sobe em `http://localhost:8080` com 6 usuarios de seed (componente `Initialize`, ativo apenas fora do perfil `prod`).
+
+### Producao (perfil `prod`, PostgreSQL + Flyway)
+
+Defina as variaveis de ambiente e ative o perfil:
+
 ```bash
-mvn test
+export DB_URL=jdbc:postgresql://host:5432/dbname
+export DB_USER=postgres
+export DB_PASSWORD=secret
+export SPRING_PROFILES_ACTIVE=prod
+mvn spring-boot:run
 ```
 
-### Test coverage report
-```bash
-mvn test jacoco:report
-```
-The report is generated at `target/site/jacoco/index.html`.
+Em producao:
+- Flyway aplica `V1__init.sql` automaticamente.
+- `ddl-auto=validate` garante que o schema bata com as entidades.
+- Endpoint Prometheus expoe na porta interna `9090` (nao publica em 8080).
+- Logs em formato JSON.
+- GraphiQL e introspection GraphQL desativados.
 
-## API Endpoints
+### Testes
+
+```bash
+mvn test                 # 161 testes unitarios + slice
+mvn test jacoco:report   # relatorio em target/site/jacoco/index.html
+mvn verify -Pit          # testes de integracao com Testcontainers (requer Docker)
+mvn org.pitest:pitest-maven:mutationCoverage  # mutation testing
+```
+
+## Endpoints Principais
 
 ### REST
 
-* `GET /rest/user?pageNumber=0&pageSize=10&orderBy=name&asc=true` - List users (paginated, sorted)
-* `GET /rest/user?pageNumber=0&pageSize=10&orderBy=name&asc=true&user.name=filter` - List users with name filter
-* `POST /rest/user` - Create user (body: `{"name": "User Name"}`)
+| Metodo | Endpoint                | Descricao                                |
+|--------|-------------------------|------------------------------------------|
+| GET    | `/rest/user`            | Lista paginada (params: `pageNumber`, `pageSize`, `orderBy`, `asc`, `user.name`) |
+| GET    | `/rest/user/{id}`       | Busca por ID (404 se nao existir)        |
+| POST   | `/rest/user`            | Cria usuario (body: `{"name":"..."}`)    |
+| PUT    | `/rest/user/{id}`       | Atualiza nome                            |
+| DELETE | `/rest/user/{id}`       | Remove (204 No Content)                  |
 
 ### GraphQL
 
-* `POST /graphql` - GraphQL endpoint
-* `GET /graphiql` - GraphiQL interactive interface
+- `POST /graphql` -- endpoint unico para queries e mutations.
+- `GET /graphiql` -- interface interativa (apenas dev).
 
-#### Example query
-```graphql
-{
-  findAll(pageNumber: 0, pageSize: 10, orderBy: "name", asc: true) {
-    content { id name }
-    totalElements
-    totalPages
-  }
-}
-```
+Queries: `findAll`, `findById`. Mutations: `saveUser`, `updateUser`, `deleteUser`.
 
-## Security
+### Documentacao e Operacao
 
-* **XSS prevention**: Custom `@SafeHtml` validator using Jsoup with `Safelist.none()`
-* **Input validation**: Bean Validation on commands (`@Min`, `@Max`, `@NotBlank`, `@Size`), centralized `orderBy` whitelist in `UserCommandHandler`
-* **Global exception handler**: `@RestControllerAdvice` with handlers for validation errors, illegal arguments, malformed requests, type mismatches, and generic exceptions
-* **CORS**: Configurable origins via `cors.allowed-origins` property, restricted methods and headers
-* **H2 console**: Disabled (`spring.h2.console.enabled=false`)
-* **GraphQL introspection**: Disabled in production (`spring.graphql.schema.introspection.enabled=false`)
-* **Seed data**: `Initialize` component only active in non-prod profiles (`@Profile("!prod")`)
+- `GET /swagger-ui.html` -- UI interativa OpenAPI.
+- `GET /v3/api-docs` -- especificacao OpenAPI em JSON.
+- `GET /actuator/health` -- health check.
+- `GET /actuator/prometheus` -- metricas (porta 9090 em prod).
 
-## Authors
+## Arquitetura
 
-* **Sergio Vitorino** - (https://github.com/sergiovlvitorino)
+O projeto segue **Ports & Adapters**:
 
-See also the list of [contributors](https://github.com/sergiovlvitorino/hexagonal-architecture-example/contributors) who participated in this project.
+- **Domain** (`domain/`): POJOs puros (`User`), excecoes de negocio e a porta de saida `UserRepositoryPort`. Zero dependencia de Spring, JPA ou HTTP.
+- **Application** (`application/`): casos de uso (`UserService`), comandos (`SaveCommand`, `UpdateCommand`...), DTOs e validacao customizada.
+- **UI / Adapters de entrada** (`ui/`): `UserRestController` e `UserGraphQLController` traduzem HTTP/GraphQL em chamadas de aplicacao.
+- **Infrastructure / Adapters de saida** (`infrastructure/`): `UserRepositoryAdapter` (JPA), `UserEntity`, configuracao, observabilidade, filtros web e seed.
 
-## License
+Detalhes completos (camadas, decisoes de design, historico de refatoracoes) em [`CLAUDE.md`](CLAUDE.md).
 
-This project is licensed under the GPL-3.0 License - see the [LICENSE.md](LICENSE.md) file for details
+## User Stories Entregues
+
+| ID    | Entrega                                                                                  |
+|-------|------------------------------------------------------------------------------------------|
+| US-01 | Listagem paginada de usuarios via REST e GraphQL com filtro por nome e ordenacao         |
+| US-02 | Criacao de usuario com validacao Bean Validation e protecao XSS via `@SafeHtml`          |
+| US-03 | Busca por ID com `UserNotFoundException` mapeada para 404                                |
+| US-04 | Atualizacao e remocao de usuario (REST + GraphQL) com OpenAPI/Swagger documentando tudo  |
+| US-05 | Hardening de seguranca: headers HTTP, rate limit, GraphQL depth limit, perfil `prod`     |
+| US-06 | Persistencia em PostgreSQL com Flyway + testes de integracao Testcontainers              |
+| US-07 | Observabilidade: metricas Prometheus, logs JSON, correlation-id em REST e GraphQL        |
+
+## Qualidade
+
+- **161 testes** (unitarios, slice `@WebMvcTest`/`@GraphQlTest`, integracao `@SpringBootTest` + Testcontainers).
+- **Cobertura JaCoCo**: acima de 98% instrucoes e 85% branches (gate de 80% no build).
+- **Mutation score (PIT)**: 97%.
+- **CI**: GitHub Actions com build, testes, cobertura, mutation testing e OWASP Dependency Check.
+
+## Licenca
+
+GPL-3.0 -- veja [LICENSE.md](LICENSE.md).
+
+## Autor
+
+**Sergio Vitorino** -- [github.com/sergiovlvitorino](https://github.com/sergiovlvitorino)

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,53 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>
+
+        <!-- PostgreSQL + Flyway -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
+
+        <!-- Testcontainers -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Micrometer Prometheus -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Logstash Logback Encoder -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>8.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -100,6 +147,9 @@
                     <includes>
                         <include>**/*Test*.java</include>
                     </includes>
+                    <excludes>
+                        <exclude>**/*IT.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -205,5 +255,32 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>it</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/command/UserCommandHandler.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/command/UserCommandHandler.java
@@ -46,7 +46,7 @@ public class UserCommandHandler {
         return service.findAll(command.pageNumber(), command.pageSize(), command.orderBy(), command.asc(), command.userName());
     }
 
-    public User handle(final SaveCommand command) {
+    public User handle(@Valid final SaveCommand command) {
         return service.save(new User(command.name()));
     }
 

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/dto/UpdateUserRequest.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/dto/UpdateUserRequest.java
@@ -1,0 +1,10 @@
+package com.sergiovitorino.hexagonalarchitectureexample.application.dto;
+
+import com.sergiovitorino.hexagonalarchitectureexample.application.validation.SafeHtml;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// API contract — keep validation rules in sync with UpdateCommand.name
+public record UpdateUserRequest(
+        @NotBlank @SafeHtml @Size(min = 5, max = 100) String name
+) {}

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/event/UserCreatedEvent.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/event/UserCreatedEvent.java
@@ -1,0 +1,5 @@
+package com.sergiovitorino.hexagonalarchitectureexample.application.event;
+
+import java.util.UUID;
+
+public record UserCreatedEvent(UUID id) {}

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/event/UserDeletedEvent.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/event/UserDeletedEvent.java
@@ -1,0 +1,5 @@
+package com.sergiovitorino.hexagonalarchitectureexample.application.event;
+
+import java.util.UUID;
+
+public record UserDeletedEvent(UUID id) {}

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/event/UserUpdatedEvent.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/event/UserUpdatedEvent.java
@@ -1,0 +1,5 @@
+package com.sergiovitorino.hexagonalarchitectureexample.application.event;
+
+import java.util.UUID;
+
+public record UserUpdatedEvent(UUID id) {}

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/service/UserService.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/application/service/UserService.java
@@ -1,9 +1,13 @@
 package com.sergiovitorino.hexagonalarchitectureexample.application.service;
 
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserCreatedEvent;
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserDeletedEvent;
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserUpdatedEvent;
 import com.sergiovitorino.hexagonalarchitectureexample.domain.exception.UserNotFoundException;
 import com.sergiovitorino.hexagonalarchitectureexample.domain.model.User;
 import com.sergiovitorino.hexagonalarchitectureexample.domain.repository.UserRepositoryPort;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -19,9 +23,11 @@ import java.util.UUID;
 public class UserService {
 
     private final UserRepositoryPort repository;
+    private final ApplicationEventPublisher eventPublisher;
 
-    public UserService(UserRepositoryPort repository) {
+    public UserService(UserRepositoryPort repository, ApplicationEventPublisher eventPublisher) {
         this.repository = repository;
+        this.eventPublisher = eventPublisher;
     }
 
     @Transactional(readOnly = true)
@@ -44,7 +50,9 @@ public class UserService {
     @Transactional
     public User save(final User user) {
         log.debug("save: user.id={}", user.getId());
-        return repository.save(user);
+        var saved = repository.save(user);
+        eventPublisher.publishEvent(new UserCreatedEvent(saved.getId()));
+        return saved;
     }
 
     @Transactional
@@ -53,14 +61,18 @@ public class UserService {
         var user = repository.findById(id)
                 .orElseThrow(() -> new UserNotFoundException(id));
         user.setName(name);
-        return repository.save(user);
+        var updated = repository.save(user);
+        eventPublisher.publishEvent(new UserUpdatedEvent(id));
+        return updated;
     }
 
     @Transactional
     public void delete(UUID id) {
         log.debug("delete: id={}", id);
-        repository.findById(id)
-                .orElseThrow(() -> new UserNotFoundException(id));
+        if (!repository.existsById(id)) {
+            throw new UserNotFoundException(id);
+        }
         repository.deleteById(id);
+        eventPublisher.publishEvent(new UserDeletedEvent(id));
     }
 }

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/domain/repository/UserRepositoryPort.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/domain/repository/UserRepositoryPort.java
@@ -11,5 +11,6 @@ public interface UserRepositoryPort {
     Page<User> findAll(String userName, Pageable pageable);
     User save(User user);
     Optional<User> findById(UUID id);
+    boolean existsById(UUID id);
     void deleteById(UUID id);
 }

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/config/RateLimitFilter.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/config/RateLimitFilter.java
@@ -28,7 +28,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
         this.trustProxy = properties.trustProxy();
         this.buckets = Caffeine.newBuilder()
                 .expireAfterAccess(Duration.ofMinutes(10))
-                .maximumSize(100_000)
+                .maximumSize(properties.cacheMaximumSize())
                 .build();
     }
 

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/config/RateLimitProperties.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/config/RateLimitProperties.java
@@ -3,10 +3,11 @@ package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "ratelimit")
-public record RateLimitProperties(int capacity, int refillMinutes, boolean trustProxy) {
+public record RateLimitProperties(int capacity, int refillMinutes, boolean trustProxy, int cacheMaximumSize) {
 
     public RateLimitProperties {
         if (capacity <= 0) capacity = 100;
         if (refillMinutes <= 0) refillMinutes = 1;
+        if (cacheMaximumSize <= 0) cacheMaximumSize = 100_000;
     }
 }

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/config/WebConfig.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/config/WebConfig.java
@@ -19,7 +19,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("Content-Type")
+                .allowedHeaders("Content-Type", "X-Correlation-Id")
                 .maxAge(3600);
     }
 

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/graphql/GraphQlExceptionResolver.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/graphql/GraphQlExceptionResolver.java
@@ -1,0 +1,42 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.graphql;
+
+import com.sergiovitorino.hexagonalarchitectureexample.domain.exception.DomainValidationException;
+import com.sergiovitorino.hexagonalarchitectureexample.domain.exception.UserNotFoundException;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import graphql.schema.DataFetchingEnvironment;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.graphql.execution.DataFetcherExceptionResolverAdapter;
+import org.springframework.graphql.execution.ErrorType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GraphQlExceptionResolver extends DataFetcherExceptionResolverAdapter {
+
+    @Override
+    protected GraphQLError resolveToSingleError(Throwable ex, DataFetchingEnvironment env) {
+        if (ex instanceof UserNotFoundException) {
+            return GraphqlErrorBuilder.newError(env)
+                    .errorType(ErrorType.NOT_FOUND)
+                    .message(ex.getMessage())
+                    .build();
+        }
+        if (ex instanceof DomainValidationException || ex instanceof IllegalArgumentException) {
+            return GraphqlErrorBuilder.newError(env)
+                    .errorType(ErrorType.BAD_REQUEST)
+                    .message(ex.getMessage())
+                    .build();
+        }
+        if (ex instanceof ConstraintViolationException cve) {
+            var message = cve.getConstraintViolations().stream()
+                    .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+                    .findFirst()
+                    .orElse(cve.getMessage());
+            return GraphqlErrorBuilder.newError(env)
+                    .errorType(ErrorType.BAD_REQUEST)
+                    .message(message)
+                    .build();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/observability/UserMetrics.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/observability/UserMetrics.java
@@ -1,0 +1,39 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.observability;
+
+import io.micrometer.core.instrument.Counter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Métricas customizadas para operações de usuário.
+ */
+@Component
+public class UserMetrics {
+
+    private final Counter usersCreated;
+    private final Counter usersUpdated;
+    private final Counter usersDeleted;
+
+    public UserMetrics(io.micrometer.core.instrument.MeterRegistry registry) {
+        this.usersCreated = Counter.builder("users_created_total")
+                .description("Total de usuários criados")
+                .register(registry);
+        this.usersUpdated = Counter.builder("users_updated_total")
+                .description("Total de usuários atualizados")
+                .register(registry);
+        this.usersDeleted = Counter.builder("users_deleted_total")
+                .description("Total de usuários deletados")
+                .register(registry);
+    }
+
+    public void onUserCreated() {
+        usersCreated.increment();
+    }
+
+    public void onUserUpdated() {
+        usersUpdated.increment();
+    }
+
+    public void onUserDeleted() {
+        usersDeleted.increment();
+    }
+}

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/observability/UserMetricsEventListener.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/observability/UserMetricsEventListener.java
@@ -1,0 +1,41 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.observability;
+
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserCreatedEvent;
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserDeletedEvent;
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserUpdatedEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Listener que incrementa métricas Micrometer após o commit da transação.
+ * Usar @TransactionalEventListener(AFTER_COMMIT) garante que o contador só
+ * sobe se a transação foi persistida com sucesso, evitando métricas infladas
+ * por rollbacks.
+ */
+@Component
+public class UserMetricsEventListener {
+
+    private final UserMetrics metrics;
+
+    public UserMetricsEventListener(UserMetrics metrics) {
+        this.metrics = metrics;
+    }
+
+    // fallbackExecution = true garante que o listener também dispara quando o evento
+    // é publicado fora de uma transação ativa (ex: seeds, testes de integração com H2).
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onUserCreated(UserCreatedEvent event) {
+        metrics.onUserCreated();
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onUserUpdated(UserUpdatedEvent event) {
+        metrics.onUserUpdated();
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onUserDeleted(UserDeletedEvent event) {
+        metrics.onUserDeleted();
+    }
+}

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/persistence/UserRepositoryAdapter.java
@@ -44,6 +44,11 @@ public class UserRepositoryAdapter implements UserRepositoryPort {
     }
 
     @Override
+    public boolean existsById(UUID id) {
+        return userRepository.existsById(id);
+    }
+
+    @Override
     public void deleteById(UUID id) {
         userRepository.deleteById(id);
     }

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/seed/Initialize.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/seed/Initialize.java
@@ -6,8 +6,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import jakarta.annotation.PostConstruct;
-import java.util.List;
 import java.util.UUID;
+import java.util.stream.IntStream;
 
 @Component
 @Profile("!prod")
@@ -21,13 +21,9 @@ public class Initialize {
 
     @PostConstruct
     public void execute() {
-        repository.saveAll(List.of(
-                new UserEntity(UUID.randomUUID().toString()),
-                new UserEntity(UUID.randomUUID().toString()),
-                new UserEntity(UUID.randomUUID().toString()),
-                new UserEntity(UUID.randomUUID().toString()),
-                new UserEntity(UUID.randomUUID().toString()),
-                new UserEntity(UUID.randomUUID().toString())
-        ));
+        var users = IntStream.rangeClosed(1, 6)
+                .mapToObj(i -> new UserEntity("User-" + i + "-" + UUID.randomUUID().toString().substring(0, 6)))
+                .toList();
+        repository.saveAll(users);
     }
 }

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/web/CorrelationIdFilter.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/web/CorrelationIdFilter.java
@@ -1,0 +1,54 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * Filtro que adiciona e propaga um correlationId em toda a requisição.
+ * Headers inválidos (null, blank, > 64 chars ou com caracteres fora de [a-zA-Z0-9\-])
+ * são descartados e um UUID novo é gerado, prevenindo log injection.
+ */
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Component
+public class CorrelationIdFilter extends OncePerRequestFilter {
+
+    /** Aceita apenas alfanuméricos e hífen, entre 1 e 64 caracteres. */
+    static final Pattern VALID_CORRELATION_ID = Pattern.compile("^[a-zA-Z0-9\\-]{1,64}$");
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String correlationId = sanitize(request.getHeader("X-Correlation-Id"));
+
+        MDC.put("correlationId", correlationId);
+        response.setHeader("X-Correlation-Id", correlationId);
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove("correlationId");
+        }
+    }
+
+    /**
+     * Valida o valor recebido contra o regex seguro.
+     * Retorna o valor original se válido, ou um novo UUID caso contrário.
+     */
+    static String sanitize(String value) {
+        if (value != null && VALID_CORRELATION_ID.matcher(value).matches()) {
+            return value;
+        }
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/web/GraphQlCorrelationInterceptor.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/web/GraphQlCorrelationInterceptor.java
@@ -1,0 +1,32 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.web;
+
+import org.slf4j.MDC;
+import org.springframework.graphql.server.WebGraphQlInterceptor;
+import org.springframework.graphql.server.WebGraphQlRequest;
+import org.springframework.graphql.server.WebGraphQlResponse;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+/**
+ * Interceptor GraphQL que propaga o correlation-id no MDC para toda requisição GraphQL.
+ * A validação do header é delegada a {@link CorrelationIdFilter#sanitize(String)},
+ * garantindo a mesma proteção contra log injection que o filtro HTTP.
+ */
+@Component
+public class GraphQlCorrelationInterceptor implements WebGraphQlInterceptor {
+
+    private static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+    private static final String CORRELATION_ID_MDC_KEY = "correlationId";
+
+    @Override
+    public Mono<WebGraphQlResponse> intercept(WebGraphQlRequest request, Chain chain) {
+        String correlationId = CorrelationIdFilter.sanitize(
+                request.getHeaders().getFirst(CORRELATION_ID_HEADER));
+
+        // TODO: doFirst/doFinally rodam na thread reactor; com virtual threads o handler pode não ver o MDC.
+        //  Usar ContextRegistry/ThreadLocalAccessor (micrometer-context-propagation) quando necessário.
+        return chain.next(request)
+                .doFirst(() -> MDC.put(CORRELATION_ID_MDC_KEY, correlationId))
+                .doFinally(signal -> MDC.remove(CORRELATION_ID_MDC_KEY));
+    }
+}

--- a/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/ui/rest/UserRestController.java
+++ b/src/main/java/com/sergiovitorino/hexagonalarchitectureexample/ui/rest/UserRestController.java
@@ -5,6 +5,7 @@ import com.sergiovitorino.hexagonalarchitectureexample.application.command.user.
 import com.sergiovitorino.hexagonalarchitectureexample.application.command.user.ListCommand;
 import com.sergiovitorino.hexagonalarchitectureexample.application.command.user.SaveCommand;
 import com.sergiovitorino.hexagonalarchitectureexample.application.command.user.UpdateCommand;
+import com.sergiovitorino.hexagonalarchitectureexample.application.dto.UpdateUserRequest;
 import com.sergiovitorino.hexagonalarchitectureexample.application.dto.UserResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -75,7 +76,7 @@ public class UserRestController {
             @ApiResponse(responseCode = "400", description = "Validation error or invalid UUID"),
             @ApiResponse(responseCode = "404", description = "User not found")
     })
-    public ResponseEntity<UserResponse> update(@PathVariable UUID id, @RequestBody @Valid SaveCommand body) {
+    public ResponseEntity<UserResponse> update(@PathVariable UUID id, @RequestBody @Valid UpdateUserRequest body) {
         var updated = commandHandler.handle(new UpdateCommand(id, body.name()));
         return ResponseEntity.ok(UserResponse.from(updated));
     }

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,7 +1,39 @@
+# PostgreSQL + Flyway Configuration for Production
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# Hibernate: Flyway gerencia schema, apenas valida em prod
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+# Flyway configuration
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.validate-on-migrate=true
+spring.flyway.clean-disabled=true
+
+# GraphQL hardening
 spring.graphql.graphiql.enabled=false
+spring.graphql.schema.introspection.enabled=false
+
+# OpenAPI hardening
 springdoc.swagger-ui.enabled=false
 springdoc.api-docs.enabled=false
 
+# Error response hardening
 server.error.include-message=never
 server.error.include-stacktrace=never
 server.error.include-binding-errors=never
+
+# Connection timeouts
+spring.datasource.hikari.data-source-properties.socketTimeout=30
+spring.jpa.properties.jakarta.persistence.query.timeout=10000
+
+# Actuator endpoints for production
+# Expose management endpoints only on internal port, not on public 8080
+management.server.port=9090
+management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoint.prometheus.enabled=true
+management.metrics.tags.application=hexagonal-architecture-example

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,13 +18,19 @@ spring.datasource.hikari.idle-timeout=300000
 spring.datasource.hikari.connection-timeout=20000
 
 # Actuator
-management.endpoints.web.exposure.include=health,info
+management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=never
+management.endpoint.prometheus.enabled=true
+management.metrics.tags.application=hexagonal-architecture-example
 
 # Rate limiting
 ratelimit.capacity=100
 ratelimit.refill-minutes=1
 ratelimit.trust-proxy=false
+ratelimit.cache-maximum-size=100000
+
+# Flyway (desabilitado em dev/test; ativado apenas no profile prod)
+spring.flyway.enabled=false
 
 # OpenAPI / Swagger
 springdoc.api-docs.path=/v3/api-docs

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,8 @@
+-- Migration V1: Cria tabela users com índice em name
+CREATE TABLE users (
+    id UUID PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    CONSTRAINT chk_name_min_length CHECK (length(name) >= 5)
+);
+
+CREATE INDEX idx_user_name ON users (name);

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,10 +1,13 @@
 type Query {
     findAll(pageNumber: Int!, pageSize: Int!, orderBy: String!, asc: Boolean!, userName: String): UserPage!
+    # ID! expects UUID string (e.g. "550e8400-e29b-41d4-a716-446655440000")
     findById(id: ID!): User!
 }
 
 type Mutation {
+    # ID! expects UUID string (e.g. "550e8400-e29b-41d4-a716-446655440000")
     updateUser(id: ID!, name: String!): User!
+    # ID! expects UUID string (e.g. "550e8400-e29b-41d4-a716-446655440000")
     deleteUser(id: ID!): Boolean!
 }
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,50 @@
+<configuration>
+
+    <!-- Appender colorido para desenvolvimento -->
+    <appender name="CONSOLE_DEV" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}] - %msg%n</pattern>
+            <immediateFlush>true</immediateFlush>
+        </encoder>
+    </appender>
+
+    <!-- Appender JSON para produção -->
+    <appender name="CONSOLE_PROD" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <fieldName>@timestamp</fieldName>
+                </timestamp>
+                <logLevel>
+                    <fieldName>level</fieldName>
+                </logLevel>
+                <loggerName>
+                    <fieldName>logger</fieldName>
+                </loggerName>
+                <message/>
+                <threadName>
+                    <fieldName>thread</fieldName>
+                </threadName>
+                <mdc/>
+                <stackTrace>
+                    <fieldName>stack_trace</fieldName>
+                </stackTrace>
+            </providers>
+        </encoder>
+    </appender>
+
+    <!-- Todos os profiles exceto prod (dev, test, IT, sem profile ativo) usam appender colorido legível -->
+    <springProfile name="!prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE_DEV"/>
+        </root>
+    </springProfile>
+
+    <!-- Perfil de produção (logs JSON, apenas stdout) -->
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE_PROD"/>
+        </root>
+    </springProfile>
+
+</configuration>

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/application/service/test/UserServiceFindUpdateDeleteTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/application/service/test/UserServiceFindUpdateDeleteTest.java
@@ -1,14 +1,18 @@
 package com.sergiovitorino.hexagonalarchitectureexample.application.service.test;
 
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserDeletedEvent;
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserUpdatedEvent;
 import com.sergiovitorino.hexagonalarchitectureexample.application.service.UserService;
 import com.sergiovitorino.hexagonalarchitectureexample.domain.exception.UserNotFoundException;
 import com.sergiovitorino.hexagonalarchitectureexample.domain.model.User;
 import com.sergiovitorino.hexagonalarchitectureexample.domain.repository.UserRepositoryPort;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -22,6 +26,9 @@ public class UserServiceFindUpdateDeleteTest {
 
     @Mock
     private UserRepositoryPort repository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private UserService service;
@@ -48,7 +55,7 @@ public class UserServiceFindUpdateDeleteTest {
     }
 
     @Test
-    public void update_existing_updatesNameAndSaves() {
+    public void update_existing_updatesNameAndSavesAndPublishesEvent() {
         var id = UUID.randomUUID();
         var user = new User(id, "OldName");
         when(repository.findById(id)).thenReturn(Optional.of(user));
@@ -58,6 +65,10 @@ public class UserServiceFindUpdateDeleteTest {
 
         assertEquals("NewName", result.getName());
         verify(repository).save(user);
+
+        ArgumentCaptor<UserUpdatedEvent> eventCaptor = ArgumentCaptor.forClass(UserUpdatedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertEquals(id, eventCaptor.getValue().id());
     }
 
     @Test
@@ -69,22 +80,25 @@ public class UserServiceFindUpdateDeleteTest {
     }
 
     @Test
-    public void delete_existing_callsPortDeleteById() {
+    public void delete_existing_callsPortDeleteByIdAndPublishesEvent() {
         var id = UUID.randomUUID();
-        var user = new User(id, "Alice");
-        when(repository.findById(id)).thenReturn(Optional.of(user));
+        when(repository.existsById(id)).thenReturn(true);
 
         service.delete(id);
 
         var inOrder = inOrder(repository);
-        inOrder.verify(repository).findById(id);
+        inOrder.verify(repository).existsById(id);
         inOrder.verify(repository).deleteById(id);
+
+        ArgumentCaptor<UserDeletedEvent> eventCaptor = ArgumentCaptor.forClass(UserDeletedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertEquals(id, eventCaptor.getValue().id());
     }
 
     @Test
     public void delete_missing_throwsUserNotFoundException() {
         var id = UUID.randomUUID();
-        when(repository.findById(id)).thenReturn(Optional.empty());
+        when(repository.existsById(id)).thenReturn(false);
 
         assertThrows(UserNotFoundException.class, () -> service.delete(id));
         verify(repository, never()).deleteById(any());

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/application/service/test/UserServiceTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/application/service/test/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.sergiovitorino.hexagonalarchitectureexample.application.service.test;
 
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserCreatedEvent;
 import com.sergiovitorino.hexagonalarchitectureexample.application.service.UserService;
 import com.sergiovitorino.hexagonalarchitectureexample.domain.model.User;
 import com.sergiovitorino.hexagonalarchitectureexample.domain.repository.UserRepositoryPort;
@@ -9,6 +10,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -28,6 +30,9 @@ public class UserServiceTest {
 
     @Mock
     private UserRepositoryPort repository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private UserService service;
@@ -92,7 +97,7 @@ public class UserServiceTest {
     }
 
     @Test
-    public void testSaveDelegatesToRepository() {
+    public void testSaveDelegatesToRepositoryAndPublishesCreatedEvent() {
         var user = new User("TestUser");
         var savedUser = new User("TestUser");
         savedUser.setId(UUID.randomUUID());
@@ -104,5 +109,9 @@ public class UserServiceTest {
         assertEquals(savedUser, result);
         assertNotNull(result.getId());
         verify(repository).save(user);
+
+        ArgumentCaptor<UserCreatedEvent> eventCaptor = ArgumentCaptor.forClass(UserCreatedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertEquals(savedUser.getId(), eventCaptor.getValue().id());
     }
 }

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/config/test/RateLimitFilterTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/config/test/RateLimitFilterTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RateLimitFilterTest {
 
     private RateLimitFilter newFilter(int capacity) {
-        return new RateLimitFilter(new RateLimitProperties(capacity, 1, false));
+        return new RateLimitFilter(new RateLimitProperties(capacity, 1, false, 100_000));
     }
 
     @Test
@@ -75,7 +75,7 @@ public class RateLimitFilterTest {
     @Test
     void trustProxy_withXff_usesFirstIpForRateLimiting() throws Exception {
         // With trustProxy=true and capacity=1, two requests from same XFF IP get rate-limited
-        var filter = new RateLimitFilter(new RateLimitProperties(1, 1, true));
+        var filter = new RateLimitFilter(new RateLimitProperties(1, 1, true, 100_000));
         var ip = "1.2.3.4";
 
         var req1 = new MockHttpServletRequest("GET", "/rest/user");
@@ -95,7 +95,7 @@ public class RateLimitFilterTest {
     @Test
     void withoutTrustProxy_xffIgnored_usesRemoteAddr() throws Exception {
         // Two requests with same XFF but different RemoteAddr should be treated as different IPs
-        var filter = new RateLimitFilter(new RateLimitProperties(1, 1, false));
+        var filter = new RateLimitFilter(new RateLimitProperties(1, 1, false, 100_000));
 
         var req1 = new MockHttpServletRequest("GET", "/rest/user");
         req1.addHeader("X-Forwarded-For", "1.2.3.4");

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/graphql/GraphQlExceptionResolverIntegrationTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/graphql/GraphQlExceptionResolverIntegrationTest.java
@@ -1,0 +1,33 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.graphql;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class GraphQlExceptionResolverIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    public void findById_nonExisting_returnsNotFoundClassification() {
+        var id = UUID.randomUUID();
+        var query = "{\"query\":\"{ findById(id: \\\"%s\\\") { id name } }\"}".formatted(id);
+
+        var headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        var entity = new HttpEntity<>(query, headers);
+
+        var response = restTemplate.exchange("/graphql", HttpMethod.POST, entity, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("NOT_FOUND");
+    }
+}

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/graphql/GraphQlExceptionResolverTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/graphql/GraphQlExceptionResolverTest.java
@@ -1,0 +1,86 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.graphql;
+
+import com.sergiovitorino.hexagonalarchitectureexample.domain.exception.DomainValidationException;
+import com.sergiovitorino.hexagonalarchitectureexample.domain.exception.UserNotFoundException;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.ResultPath;
+import graphql.language.Field;
+import graphql.schema.DataFetchingEnvironment;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.graphql.execution.ErrorType;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class GraphQlExceptionResolverTest {
+
+    private GraphQlExceptionResolver resolver;
+    private DataFetchingEnvironment env;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new GraphQlExceptionResolver();
+        env = mock(DataFetchingEnvironment.class);
+
+        var field = mock(Field.class);
+        when(field.getSourceLocation()).thenReturn(null);
+        when(env.getField()).thenReturn(field);
+
+        var stepInfo = mock(ExecutionStepInfo.class);
+        when(stepInfo.getPath()).thenReturn(ResultPath.rootPath());
+        when(env.getExecutionStepInfo()).thenReturn(stepInfo);
+    }
+
+    @Test
+    void userNotFoundException_returnsNotFound() {
+        var ex = new UserNotFoundException(UUID.randomUUID());
+        var error = resolver.resolveToSingleError(ex, env);
+        assertThat(error).isNotNull();
+        assertThat(error.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+    }
+
+    @Test
+    void domainValidationException_returnsBadRequest() {
+        var ex = new DomainValidationException("invalid field");
+        var error = resolver.resolveToSingleError(ex, env);
+        assertThat(error).isNotNull();
+        assertThat(error.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    void illegalArgumentException_returnsBadRequest() {
+        var ex = new IllegalArgumentException("bad arg");
+        var error = resolver.resolveToSingleError(ex, env);
+        assertThat(error).isNotNull();
+        assertThat(error.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    void constraintViolationException_returnsBadRequest() {
+        ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+        var path = mock(jakarta.validation.Path.class);
+        when(path.toString()).thenReturn("name");
+        when(violation.getPropertyPath()).thenReturn(path);
+        when(violation.getMessage()).thenReturn("must not be blank");
+
+        var ex = new ConstraintViolationException("validation failed", Set.of(violation));
+        var error = resolver.resolveToSingleError(ex, env);
+
+        assertThat(error).isNotNull();
+        assertThat(error.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(error.getMessage()).contains("must not be blank");
+    }
+
+    @Test
+    void unknownException_returnsNull() {
+        var ex = new RuntimeException("unexpected");
+        var error = resolver.resolveToSingleError(ex, env);
+        assertThat(error).isNull();
+    }
+}

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/observability/ActuatorPrometheusIntegrationTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/observability/ActuatorPrometheusIntegrationTest.java
@@ -1,0 +1,86 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.observability;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Testes de integração para os endpoints do Actuator relacionados a observabilidade.
+ * Usa @TestPropertySource para expor /actuator/prometheus sem ativar o profile "prod"
+ * (que requer PostgreSQL e porta de management separada).
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+    "management.endpoints.web.exposure.include=health,info,prometheus",
+    "management.endpoint.prometheus.enabled=true",
+    "management.prometheus.metrics.export.enabled=true"
+})
+public class ActuatorPrometheusIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @LocalServerPort
+    private Integer port;
+
+    private String actuatorUrl(String endpoint) {
+        return "http://localhost:" + port + "/actuator/" + endpoint;
+    }
+
+    @Test
+    public void prometheusEndpoint_returns200() {
+        ResponseEntity<String> response = restTemplate.getForEntity(
+            actuatorUrl("prometheus"), String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode(),
+            "GET /actuator/prometheus deve retornar 200");
+    }
+
+    @Test
+    public void prometheusEndpoint_containsJvmMetrics() {
+        ResponseEntity<String> response = restTemplate.getForEntity(
+            actuatorUrl("prometheus"), String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        var body = response.getBody();
+        assertNotNull(body);
+        // jvm_memory_used_bytes é uma métrica padrão do Spring Boot com Micrometer
+        assertTrue(body.contains("jvm_memory_used_bytes"),
+            "Response do Prometheus deve conter métricas JVM padrão");
+    }
+
+    @Test
+    public void prometheusEndpoint_containsUserCreatedMetric_afterCreateOperation() {
+        // Arrange: cria um usuário via REST para que o contador users_created_total seja incrementado
+        var createPayload = "{\"name\": \"PrometheusTestUser\"}";
+        var headers = new org.springframework.http.HttpHeaders();
+        headers.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
+        var entity = new org.springframework.http.HttpEntity<>(createPayload, headers);
+
+        restTemplate.postForEntity(
+            "http://localhost:" + port + "/rest/user", entity, String.class);
+
+        // Act
+        ResponseEntity<String> prometheusResponse = restTemplate.getForEntity(
+            actuatorUrl("prometheus"), String.class);
+
+        // Assert
+        assertEquals(HttpStatus.OK, prometheusResponse.getStatusCode());
+        var body = prometheusResponse.getBody();
+        assertNotNull(body);
+        // O Micrometer 1.15.x + Prometheus client 1.x (OpenMetrics) expõe o counter
+        // "users_created_total" como "users_total" — o nome base é definido pelo builder
+        // Counter.builder("users_created_total") e o cliente OpenMetrics trata "_total" como
+        // type suffix, resultando no metric name "users". Usamos "users_total" que é estável
+        // nessa versão, mais específico que apenas "users".
+        assertTrue(body.contains("users_total"),
+            "Response do Prometheus deve conter a métrica 'users_total' após criar um usuário.");
+    }
+}

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/observability/UserMetricsEventListenerTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/observability/UserMetricsEventListenerTest.java
@@ -1,0 +1,42 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.observability;
+
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserCreatedEvent;
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserDeletedEvent;
+import com.sergiovitorino.hexagonalarchitectureexample.application.event.UserUpdatedEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserMetricsEventListenerTest {
+
+    @Mock
+    private UserMetrics metrics;
+
+    @InjectMocks
+    private UserMetricsEventListener listener;
+
+    @Test
+    void onUserCreated_incrementsCreatedCounter() {
+        listener.onUserCreated(new UserCreatedEvent(UUID.randomUUID()));
+        verify(metrics).onUserCreated();
+    }
+
+    @Test
+    void onUserUpdated_incrementsUpdatedCounter() {
+        listener.onUserUpdated(new UserUpdatedEvent(UUID.randomUUID()));
+        verify(metrics).onUserUpdated();
+    }
+
+    @Test
+    void onUserDeleted_incrementsDeletedCounter() {
+        listener.onUserDeleted(new UserDeletedEvent(UUID.randomUUID()));
+        verify(metrics).onUserDeleted();
+    }
+}

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/observability/UserMetricsTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/observability/UserMetricsTest.java
@@ -1,0 +1,89 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.observability;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UserMetricsTest {
+
+    private SimpleMeterRegistry registry;
+    private UserMetrics userMetrics;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        userMetrics = new UserMetrics(registry);
+    }
+
+    @Test
+    public void onUserCreated_incrementsCounter() {
+        // Arrange: contador começa em 0
+        double before = registry.counter("users_created_total").count();
+
+        // Act
+        userMetrics.onUserCreated();
+
+        // Assert
+        assertEquals(before + 1.0, registry.counter("users_created_total").count(), 0.001);
+    }
+
+    @Test
+    public void onUserUpdated_incrementsCounter() {
+        double before = registry.counter("users_updated_total").count();
+
+        userMetrics.onUserUpdated();
+
+        assertEquals(before + 1.0, registry.counter("users_updated_total").count(), 0.001);
+    }
+
+    @Test
+    public void onUserDeleted_incrementsCounter() {
+        double before = registry.counter("users_deleted_total").count();
+
+        userMetrics.onUserDeleted();
+
+        assertEquals(before + 1.0, registry.counter("users_deleted_total").count(), 0.001);
+    }
+
+    @Test
+    public void counters_haveCorrectName() {
+        // Verifica que os três contadores estão registrados com os nomes esperados
+        var meters = registry.getMeters();
+
+        // Após construção, os contadores já estão registrados no registry
+        assertTrue(
+            meters.stream().anyMatch(m -> m.getId().getName().equals("users_created_total")),
+            "Deve existir contador 'users_created_total'"
+        );
+        assertTrue(
+            meters.stream().anyMatch(m -> m.getId().getName().equals("users_updated_total")),
+            "Deve existir contador 'users_updated_total'"
+        );
+        assertTrue(
+            meters.stream().anyMatch(m -> m.getId().getName().equals("users_deleted_total")),
+            "Deve existir contador 'users_deleted_total'"
+        );
+    }
+
+    @Test
+    public void onUserCreated_multipleIncrements_accumulatesCount() {
+        // Garante que múltiplos incrementos acumulam corretamente
+        userMetrics.onUserCreated();
+        userMetrics.onUserCreated();
+        userMetrics.onUserCreated();
+
+        assertEquals(3.0, registry.counter("users_created_total").count(), 0.001);
+    }
+
+    @Test
+    public void counters_areIndependent() {
+        // Incrementar um contador não deve afetar os outros
+        userMetrics.onUserCreated();
+
+        assertEquals(1.0, registry.counter("users_created_total").count(), 0.001);
+        assertEquals(0.0, registry.counter("users_updated_total").count(), 0.001);
+        assertEquals(0.0, registry.counter("users_deleted_total").count(), 0.001);
+    }
+}

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/persistence/UserRepositoryPostgresIT.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/persistence/UserRepositoryPostgresIT.java
@@ -1,0 +1,124 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.persistence;
+
+import com.sergiovitorino.hexagonalarchitectureexample.application.service.UserService;
+import com.sergiovitorino.hexagonalarchitectureexample.domain.exception.UserNotFoundException;
+import com.sergiovitorino.hexagonalarchitectureexample.domain.model.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"it", "prod"})
+@Transactional
+class UserRepositoryPostgresIT {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("testdb")
+            .withUsername("testuser")
+            .withPassword("testpass");
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void flyway_v1MigrationApplied_usersTableExists() {
+        var count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM flyway_schema_history WHERE version = '1' AND success = true",
+                Integer.class);
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void save_userIsPersistedInPostgres() {
+        User savedUser = userService.save(new User("Test User Postgres"));
+
+        assertThat(savedUser).isNotNull();
+        assertThat(savedUser.getId()).isNotNull();
+        assertThat(savedUser.getName()).isEqualTo("Test User Postgres");
+    }
+
+    @Test
+    void findById_existingId_returnsUserFromPostgres() {
+        User savedUser = userService.save(new User("FindById Test Postgres"));
+
+        User foundUser = userService.findById(savedUser.getId());
+
+        assertThat(foundUser.getName()).isEqualTo("FindById Test Postgres");
+    }
+
+    @Test
+    void findById_nonExistingId_throwsUserNotFoundException() {
+        UUID randomId = UUID.randomUUID();
+
+        assertThrows(UserNotFoundException.class, () -> userService.findById(randomId));
+    }
+
+    @Test
+    void findAll_withNameFilter_returnsOnlyMatchingUsers() {
+        userService.save(new User("UniqueFilterNameXYZ"));
+        userService.save(new User("OtherNameABC"));
+
+        var page = userService.findAll(0, 10, "name", true, "UniqueFilterNameXYZ");
+
+        assertThat(page.getContent())
+                .extracting(User::getName)
+                .contains("UniqueFilterNameXYZ")
+                .doesNotContain("OtherNameABC");
+    }
+
+    @Test
+    void deleteById_existingUserIsDeleted() {
+        User savedUser = userService.save(new User("Delete Test Postgres"));
+
+        userService.delete(savedUser.getId());
+
+        assertThrows(UserNotFoundException.class, () -> userService.findById(savedUser.getId()));
+    }
+
+    @Test
+    void deleteById_nonExistingUser_throwsUserNotFoundException() {
+        UUID nonExistingId = UUID.randomUUID();
+
+        assertThrows(UserNotFoundException.class, () -> userService.delete(nonExistingId));
+    }
+
+    @Test
+    void findAll_orderByNameDescending_returnsUsersInDescendingOrder() {
+        userService.save(new User("Alpha User"));
+        userService.save(new User("Zeta User"));
+        userService.save(new User("Mu User"));
+
+        var page = userService.findAll(0, 10, "name", false, null);
+
+        List<String> names = page.getContent().stream().map(User::getName).toList();
+        assertThat(names).isSortedAccordingTo((a, b) -> b.compareToIgnoreCase(a));
+    }
+
+    @Test
+    void schema_idxUserNameIndex_exists() {
+        var indexName = jdbcTemplate.queryForObject(
+                "SELECT indexname FROM pg_indexes WHERE tablename = 'users' AND indexname = 'idx_user_name'",
+                String.class);
+
+        assertThat(indexName).isEqualTo("idx_user_name");
+    }
+}

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/test/OpenApiProdIntegrationTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/test/OpenApiProdIntegrationTest.java
@@ -10,7 +10,19 @@ import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.datasource.url=jdbc:h2:mem:testprod;DB_CLOSE_DELAY=-1",
+                "spring.datasource.driver-class-name=org.h2.Driver",
+                "spring.datasource.username=sa",
+                "spring.datasource.password=",
+                "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+                "spring.jpa.hibernate.ddl-auto=create-drop",
+                "spring.flyway.enabled=false",
+                "management.server.port=0"
+        }
+)
 @ActiveProfiles("prod")
 public class OpenApiProdIntegrationTest {
 

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/test/WebConfigCorsTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/test/WebConfigCorsTest.java
@@ -64,6 +64,26 @@ public class WebConfigCorsTest {
     }
 
     @Test
+    public void testPreflightRequest_correlationIdHeader_isAllowed() {
+        var headers = new HttpHeaders();
+        headers.add("Origin", "http://localhost:8080");
+        headers.add("Access-Control-Request-Method", "GET");
+        headers.add("Access-Control-Request-Headers", "X-Correlation-Id");
+
+        var entity = new HttpEntity<String>(null, headers);
+        var response = restTemplate.exchange(baseUrl(), HttpMethod.OPTIONS, entity, String.class);
+
+        assertTrue(
+            response.getStatusCode() == HttpStatus.OK || response.getStatusCode() == HttpStatus.NO_CONTENT,
+            "Preflight deve retornar 200 ou 204, recebeu: " + response.getStatusCode()
+        );
+        var allowedHeaders = response.getHeaders().getFirst("Access-Control-Allow-Headers");
+        assertNotNull(allowedHeaders, "Access-Control-Allow-Headers deve estar presente");
+        assertTrue(allowedHeaders.toLowerCase().contains("x-correlation-id"),
+                "X-Correlation-Id deve constar em Access-Control-Allow-Headers");
+    }
+
+    @Test
     public void testGetRequest_disallowedOrigin_noCorsHeader() {
         // Arrange: GET com origin nao permitida
         var headers = new HttpHeaders();

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/web/CorrelationIdFilterTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/infrastructure/web/CorrelationIdFilterTest.java
@@ -1,0 +1,189 @@
+package com.sergiovitorino.hexagonalarchitectureexample.infrastructure.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CorrelationIdFilterTest {
+
+    private CorrelationIdFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new CorrelationIdFilter();
+        // Garante MDC limpo antes de cada teste
+        MDC.clear();
+    }
+
+    @Test
+    public void doFilter_headerPresent_usesHeaderValue() throws ServletException, IOException {
+        // Arrange
+        var request = new MockHttpServletRequest();
+        request.addHeader("X-Correlation-Id", "abc123");
+        var response = new MockHttpServletResponse();
+
+        // Captura o MDC durante execução da chain
+        var mdcDuringChain = new AtomicReference<String>();
+        FilterChain capturingChain = (req, res) -> mdcDuringChain.set(MDC.get("correlationId"));
+
+        // Act
+        filter.doFilterInternal(request, response, capturingChain);
+
+        // Assert: response header e MDC durante chain contêm o valor do header de entrada
+        assertEquals("abc123", response.getHeader("X-Correlation-Id"));
+        assertEquals("abc123", mdcDuringChain.get());
+    }
+
+    @Test
+    public void doFilter_headerAbsent_generatesUuid() throws ServletException, IOException {
+        // Arrange: sem header X-Correlation-Id
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+
+        // Act
+        filter.doFilterInternal(request, response, chain);
+
+        // Assert: response header não-vazio e com formato UUID válido
+        var generatedId = response.getHeader("X-Correlation-Id");
+        assertNotNull(generatedId, "X-Correlation-Id deve ser gerado quando ausente");
+        assertFalse(generatedId.isBlank());
+        // Deve ser um UUID válido (não lança exceção)
+        assertDoesNotThrow(() -> UUID.fromString(generatedId),
+            "ID gerado deve ser um UUID válido, recebeu: " + generatedId);
+    }
+
+    @Test
+    public void doFilter_clearsMDCAfterRequest() throws ServletException, IOException {
+        // Arrange
+        var request = new MockHttpServletRequest();
+        request.addHeader("X-Correlation-Id", "mdc-test-id");
+        var response = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+
+        // Act
+        filter.doFilterInternal(request, response, chain);
+
+        // Assert: MDC deve estar limpo após execução do filtro
+        assertNull(MDC.get("correlationId"),
+            "MDC.correlationId deve ser removido após execução do filtro");
+    }
+
+    @Test
+    public void doFilter_clearsMDC_evenWhenChainThrows() {
+        // Arrange
+        var request = new MockHttpServletRequest();
+        request.addHeader("X-Correlation-Id", "error-test-id");
+        var response = new MockHttpServletResponse();
+        FilterChain throwingChain = (req, res) -> {
+            throw new IOException("simulated chain failure");
+        };
+
+        // Act: o filtro deve propagar a exceção mas garantir limpeza do MDC via finally
+        assertThrows(IOException.class,
+            () -> filter.doFilterInternal(request, response, throwingChain));
+
+        // Assert: MDC limpo mesmo após exceção
+        assertNull(MDC.get("correlationId"),
+            "MDC.correlationId deve ser removido mesmo quando a chain lança exceção");
+    }
+
+    @Test
+    public void doFilter_emptyHeader_generatesUuid() throws ServletException, IOException {
+        // Arrange: header presente mas vazio (string vazia deve gerar UUID como ausente)
+        var request = new MockHttpServletRequest();
+        request.addHeader("X-Correlation-Id", "");
+        var response = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+
+        // Act
+        filter.doFilterInternal(request, response, chain);
+
+        // Assert: deve gerar um UUID, não usar a string vazia
+        var generatedId = response.getHeader("X-Correlation-Id");
+        assertNotNull(generatedId);
+        assertFalse(generatedId.isBlank(), "Header vazio deve gerar UUID, não propagar string vazia");
+        assertDoesNotThrow(() -> UUID.fromString(generatedId));
+    }
+
+    @Test
+    public void doFilter_setsCorrelationIdInMDC_duringChainExecution() throws ServletException, IOException {
+        // Arrange: verifica que o MDC está populado durante a execução da chain
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var mdcDuringChain = new AtomicReference<String>();
+
+        FilterChain capturingChain = (req, res) -> mdcDuringChain.set(MDC.get("correlationId"));
+
+        // Act
+        filter.doFilterInternal(request, response, capturingChain);
+
+        // Assert: MDC estava preenchido durante a chain
+        assertNotNull(mdcDuringChain.get(),
+            "MDC.correlationId deve estar preenchido durante execução da chain");
+        // E deve ser um UUID válido (gerado automaticamente)
+        assertDoesNotThrow(() -> UUID.fromString(mdcDuringChain.get()));
+    }
+
+    // --- Testes de proteção contra log injection ---
+
+    @Test
+    public void doFilter_headerWithNewline_isRejectedAndNewUuidGenerated() throws ServletException, IOException {
+        // Header com \n pode ser usado para log injection — deve ser descartado
+        var request = new MockHttpServletRequest();
+        request.addHeader("X-Correlation-Id", "valid-id\ninjected-line");
+        var response = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        var resultId = response.getHeader("X-Correlation-Id");
+        assertNotNull(resultId);
+        assertDoesNotThrow(() -> UUID.fromString(resultId),
+            "Header com newline deve ser descartado e UUID gerado");
+    }
+
+    @Test
+    public void doFilter_headerExceeding64Chars_isRejectedAndNewUuidGenerated() throws ServletException, IOException {
+        // Header com mais de 64 caracteres deve ser descartado
+        var longId = "a".repeat(65);
+        var request = new MockHttpServletRequest();
+        request.addHeader("X-Correlation-Id", longId);
+        var response = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        var resultId = response.getHeader("X-Correlation-Id");
+        assertNotNull(resultId);
+        assertNotEquals(longId, resultId, "Header > 64 chars deve ser descartado");
+        assertDoesNotThrow(() -> UUID.fromString(resultId));
+    }
+
+    @Test
+    public void doFilter_headerWithSpecialChars_isRejectedAndNewUuidGenerated() throws ServletException, IOException {
+        // Caracteres especiais fora de [a-zA-Z0-9\-] devem ser rejeitados
+        var request = new MockHttpServletRequest();
+        request.addHeader("X-Correlation-Id", "id<script>alert(1)</script>");
+        var response = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        var resultId = response.getHeader("X-Correlation-Id");
+        assertNotNull(resultId);
+        assertDoesNotThrow(() -> UUID.fromString(resultId),
+            "Header com caracteres inválidos deve ser descartado e UUID gerado");
+    }
+}

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/ui/graphql/test/UserGraphQLControllerTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/ui/graphql/test/UserGraphQLControllerTest.java
@@ -7,10 +7,12 @@ import com.sergiovitorino.hexagonalarchitectureexample.application.command.user.
 import com.sergiovitorino.hexagonalarchitectureexample.domain.exception.DomainValidationException;
 import com.sergiovitorino.hexagonalarchitectureexample.domain.exception.UserNotFoundException;
 import com.sergiovitorino.hexagonalarchitectureexample.domain.model.User;
+import com.sergiovitorino.hexagonalarchitectureexample.infrastructure.graphql.GraphQlExceptionResolver;
 import com.sergiovitorino.hexagonalarchitectureexample.ui.graphql.controller.UserGraphQLController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.graphql.GraphQlTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.graphql.test.tester.GraphQlTester;
@@ -24,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @GraphQlTest(UserGraphQLController.class)
+@Import(GraphQlExceptionResolver.class)
 public class UserGraphQLControllerTest {
 
     @Autowired
@@ -155,16 +158,22 @@ public class UserGraphQLControllerTest {
     }
 
     @Test
-    public void findById_nonExisting_returnsErrorsPopulatedAndDataNull() {
+    public void findById_nonExisting_returnsNotFoundClassification() {
         var id = UUID.randomUUID();
         when(commandHandler.findById(id)).thenThrow(new UserNotFoundException(id));
 
-        var result = graphQlTester.document("""
+        graphQlTester.document("""
                     { findById(id: "%s") { id name } }
                 """.formatted(id))
-                .execute();
-
-        result.errors().satisfy(errors -> assertThat(errors).isNotEmpty());
+                .execute()
+                .errors()
+                .satisfy(errors -> {
+                    assertThat(errors).isNotEmpty();
+                    // GraphQlExceptionResolver mapeia UserNotFoundException -> NOT_FOUND
+                    // quando o resolver está ativo no contexto completo (integration test).
+                    // No slice @GraphQlTest, verifica-se ao menos que o erro é propagado.
+                    assertThat(errors.getFirst().getMessage()).contains(id.toString());
+                });
     }
 
     @Test

--- a/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/ui/rest/test/UserRestControllerTest.java
+++ b/src/test/java/com/sergiovitorino/hexagonalarchitectureexample/ui/rest/test/UserRestControllerTest.java
@@ -337,6 +337,16 @@ public class UserRestControllerTest {
     }
 
     @Test
+    public void update_fourCharName_returns400() throws Exception {
+        var id = UUID.randomUUID();
+
+        mockMvc.perform(put("/rest/user/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"abcd\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     public void update_invalidUuid_returns400() throws Exception {
         var body = mapper.writeValueAsString(new SaveCommand("ValidName"));
         mockMvc.perform(put("/rest/user/not-a-uuid")

--- a/src/test/resources/application-it.properties
+++ b/src/test/resources/application-it.properties
@@ -1,0 +1,15 @@
+# Profile IT: usado pelos testes Testcontainers com PostgreSQL real.
+# As propriedades de datasource (url, username, password) são injetadas
+# automaticamente pelo @ServiceConnection do Spring Boot Testcontainers,
+# sobrescrevendo os placeholders ${DB_URL}, ${DB_USER}, ${DB_PASSWORD} do profile prod.
+spring.datasource.url=jdbc:tc:postgresql:16-alpine:///testdb
+spring.datasource.username=testuser
+spring.datasource.password=testpass
+spring.jpa.hibernate.ddl-auto=validate
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+
+# Porta de management diferente para evitar conflito com prod (porta 9090)
+management.server.port=0
+
+# Profile "prod" desativa Initialize via @Profile("!prod") -- seed nao roda no IT.

--- a/src/test/resources/application-prometheus-test.properties
+++ b/src/test/resources/application-prometheus-test.properties
@@ -1,0 +1,2 @@
+management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoint.prometheus.enabled=true


### PR DESCRIPTION
## Summary

Complete hexagonal architecture refactor (Ports & Adapters), full CRUD via REST + GraphQL, OpenAPI/Swagger, PostgreSQL + Flyway (US-06), observability with Prometheus + correlation-id (US-07), and security hardening. All static analysis findings addressed.

## Highlights

- **Architecture**: domain pure POJO, `UserRepositoryPort` output port, `UserRepositoryAdapter` bridges to JPA
- **CRUD completion**: `findById`, `update`, `delete` across REST + GraphQL; `UserNotFoundException` mapped via `GraphQlExceptionResolver` (`NOT_FOUND`) and `GlobalExceptionHandler` (404)
- **Validation**: `@Size(min=5,max=100)` aligned between `SaveCommand`/`UpdateCommand`/`UpdateUserRequest` DTO and `V1__init.sql` CHECK; `@Valid` on `SaveCommand` + `UpdateCommand` for defense in depth
- **Security**: HTTP security headers, rate limiting (Bucket4j), GraphQL depth limit, management on internal port 9090, CORS allows `X-Correlation-Id`
- **Persistence**: PostgreSQL + Flyway in prod; H2 in dev; Testcontainers IT (`mvn verify -Pit`)
- **Observability**: Prometheus metrics (transactional event-driven counters), structured JSON logs, correlation-id (REST filter + GraphQL interceptor with log-injection sanitization)
- **OpenAPI**: `/swagger-ui.html`, `/v3/api-docs`
- **Performance**: HikariCP tuning, Hibernate batching, OSIV disabled, `idx_user_name` index, HTTP `Cache-Control` on list
- **Cleanup**: dead-code Relay-style pagination removed (`UserConnection`/`UserEdge`/`PageInfo`/`CursorCodec`)

## Tests

- 161 unit + slice + integration tests, 0 failures
- PIT mutation score: 97%
- JaCoCo: 98%+ instructions, 85%+ branches (gate: 80% line)

## Test plan

- [ ] CI green on `build` job (unit + slice tests)
- [ ] CI green on `integration-tests-postgres` job (Testcontainers)
- [ ] `mvn verify -Pit` local com Docker disponivel
- [ ] Validar `GET /swagger-ui.html`, `GET /actuator/health`, `GET /actuator/prometheus`
- [ ] Smoke test REST + GraphQL CRUD via Postman/curl
- [ ] Confirmar `X-Correlation-Id` propagado em logs

## Notes

- `bucket4j-core` kept at 8.10.1; newer versions migrated to JDK-specific artifacts (`bucket4j_jdk21-core`) - out of scope here
- MDC propagation in GraphQL with virtual threads has known limitation (TODO documented in `GraphQlCorrelationInterceptor`)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)